### PR TITLE
Add snowflake.js

### DIFF
--- a/snowflakesjs/config/snowflakesjs.php
+++ b/snowflakesjs/config/snowflakesjs.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'enabled' => env('SNOWFLAKES_JS_ENABLED', true),
+    'size' => env('SNOWFLAKES_JS_SIZE', 1),
+    'speed' => env('SNOWFLAKES_JS_SPEED', 3),
+    'opacity' => env('SNOWFLAKES_JS_OPACITY', 0.5),
+    'density' => env('SNOWFLAKES_JS_DENSITY', 1),
+    'quality' => env('SNOWFLAKES_JS_QUALITY', 1),
+];

--- a/snowflakesjs/plugin.json
+++ b/snowflakesjs/plugin.json
@@ -1,0 +1,19 @@
+{
+    "id": "snowflakesjs",
+    "name": "SnowflakesJs",
+    "author": "notCharles",
+    "version": "1.0.0",
+    "description": "Let it snow, let it snow, let it snow, now with Javascript & options!",
+    "category": "plugin",
+    "url": "https://github.com/pelican-dev/plugins/tree/main/snowflakesjs",
+    "update_url": null,
+    "namespace": "notCharles\\SnowflakesJs",
+    "class": "SnowflakesJsPlugin",
+    "panels": null,
+    "panel_version": null,
+    "composer_packages": null,
+    "meta": {
+        "status": "enabled",
+        "status_message": null
+    }
+}

--- a/snowflakesjs/src/Providers/SnowflakesJsPluginProvider.php
+++ b/snowflakesjs/src/Providers/SnowflakesJsPluginProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace notCharles\SnowflakesJs\Providers;
+
+use Filament\Support\Facades\FilamentView;
+use Filament\View\PanelsRenderHook;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class SnowflakesJsPluginProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $enabled = config('snowflakesjs.enabled');
+        $size = config('snowflakesjs.size');
+        $speed = config('snowflakesjs.speed');
+        $opacity = config('snowflakesjs.opacity');
+        $density = config('snowflakesjs.density');
+        $quality = config('snowflakesjs.quality');
+
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::PAGE_START,
+            fn () => Blade::render(<<<'HTML'
+            <script>
+            window.SnowflakeConfig = {
+                start: {{ $enabled }},
+                size: {{ $size }},
+                speed: {{ $speed }},
+                opacity: {{ $opacity }},
+                density: {{ $density }},
+                quality: {{ $quality }},
+                index: 9,
+                mount: document.body,
+            };
+            </script>
+            <script src="https://cdn.jsdelivr.net/gh/nextapps-de/snowflake@master/snowflake.min.js"></script>
+            HTML, [
+                'enabled' => $enabled,
+                'size' => $size,
+                'speed' => $speed,
+                'opacity' => $opacity,
+                'density' => $density,
+                'quality' => $quality,
+                ])
+        );
+    }
+}

--- a/snowflakesjs/src/SnowflakesJsPlugin.php
+++ b/snowflakesjs/src/SnowflakesJsPlugin.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace notCharles\SnowflakesJs;
+
+use App\Contracts\Plugins\HasPluginSettings;
+use Filament\Contracts\Plugin;
+use Filament\Forms\Components\Slider;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Panel;
+use Filament\Schemas\Components\Group;
+use App\Traits\EnvironmentWriterTrait;
+
+class SnowflakesJsPlugin implements HasPluginSettings, Plugin
+{
+    use EnvironmentWriterTrait;
+
+    public function getId(): string
+    {
+        return 'snowflakesjs';
+    }
+
+    public function register(Panel $panel): void {}
+
+    public function boot(Panel $panel): void {}
+
+    public function getSettingsForm(): array
+    {
+        $schema = [
+            Toggle::make('SNOWFLAKES_JS_ENABLED')
+                ->label('Enable Snowflakes')
+                ->columnSpanFull()
+                ->live()
+                ->default(fn () => config('snowflakesjs.enabled')),
+            Slider::make('SNOWFLAKES_JS_SIZE')
+                ->range(minValue: 0.5, maxValue: 4)
+                ->decimalPlaces(1)
+                ->step(0.1)
+                ->label('Size')
+                ->tooltips()
+                ->hintIcon('tabler-question-mark')
+                ->hintIconTooltip('Size of the snowflakes.')
+                ->disabled(fn ($get) => !$get('SNOWFLAKES_JS_ENABLED'))
+                ->default(fn () => config('snowflakesjs.size')),
+            Slider::make('SNOWFLAKES_JS_SPEED')
+                ->label('Speed')
+                ->range(minValue: 0.5, maxValue: 3)
+                ->decimalPlaces(1)
+                ->step(0.1)
+                ->tooltips()
+                ->hintIcon('tabler-question-mark')
+                ->hintIconTooltip('Speed of the snowflakes falling.')
+                ->disabled(fn ($get) => !$get('SNOWFLAKES_JS_ENABLED'))
+                ->default(fn () => config('snowflakesjs.speed')),
+            Slider::make('SNOWFLAKES_JS_OPACITY')
+                ->label('Opacity')
+                ->range(minValue: 0.1, maxValue: 1)
+                ->decimalPlaces(1)
+                ->step(0.1)
+                ->tooltips()
+                ->hintIcon('tabler-question-mark')
+                ->hintIconTooltip('How well can you see through the snowflakes.')
+                ->disabled(fn ($get) => !$get('SNOWFLAKES_JS_ENABLED'))
+                ->default(fn () => config('snowflakesjs.opacity')),
+            Slider::make('SNOWFLAKES_JS_DENSITY')
+                ->label('Density')
+                ->range(minValue: 0.5, maxValue: 10)
+                ->decimalPlaces(1)
+                ->step(0.1)
+                ->tooltips()
+                ->hintIcon('tabler-question-mark')
+                ->hintIconTooltip('Page Density of the snowflakes. More densitiy, more snowflakes.')
+                ->disabled(fn ($get) => !$get('SNOWFLAKES_JS_ENABLED'))
+                ->default(fn () => config('snowflakesjs.density')),
+            Slider::make('SNOWFLAKES_JS_QUALITY')
+                ->label('Quality')
+                ->range(minValue: 0.1, maxValue: 1)
+                ->decimalPlaces(1)
+                ->tooltips()
+                ->hintIcon('tabler-question-mark')
+                ->hintIconTooltip('Higher quality may impact performance on some devices.')
+                ->disabled(fn ($get) => !$get('SNOWFLAKES_JS_ENABLED'))
+                ->default(fn () => config('snowflakesjs.quality')),
+        ];
+
+        return [
+            Group::make()
+                ->schema($schema)
+                ->columns(2),
+        ];
+    }
+
+    public function saveSettings(array $data): void
+    {
+        $data['SNOWFLAKES_JS_ENABLED'] = $data['SNOWFLAKES_JS_ENABLED'] ? 'true' : 'false';
+        $this->writeToEnvironment($data);
+
+        Notification::make()
+            ->title('Settings saved')
+            ->success()
+            ->send();
+    }
+}


### PR DESCRIPTION
Adds Snowflake js and allows for customization of some settings 

<img width="903" height="472" alt="image" src="https://github.com/user-attachments/assets/325ca6bb-5598-4c9c-8f1a-3cdc143ba3ee" />
<img width="2542" height="1307" alt="image" src="https://github.com/user-attachments/assets/c74932b2-2ff8-474e-a3cc-9dcaeea956d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Snowflakes JS plugin with animated snowflake effects on your pages
  * Customize snowflake animation with configurable size, speed, opacity, density, and quality settings
  * Enable or disable the effect with a simple toggle in plugin settings
  * All settings persist automatically

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->