### PR TITLE
Add Server Folders plugin

### DIFF
--- a/server-folders/README.md
+++ b/server-folders/README.md
@@ -1,0 +1,204 @@
+# Server Folders
+
+A plugin for [Pelican Panel](https://pelican.dev) that allows users to organize their servers into custom folders with role-based sharing.
+
+## Features
+
+- **Create Custom Folders** - Organize your servers into named folders with custom colors
+- **Role-Based Sharing** - Share folders with specific user roles so team members can view them
+- **Sidebar Navigation** - Quick access to folders directly from the sidebar with server count badges
+- **Live Server Stats** - View real-time CPU, Memory, and Disk usage for all servers in a folder
+- **Color Coding** - Assign colors to folders for easy visual identification
+- **Multi-Language Support** - Includes English and German translations
+
+## Screenshots
+
+### Folder List
+View all your folders with server counts in the sidebar navigation. Shared folders show a different icon.
+
+### Folder View
+See all servers in a folder with live resource monitoring (CPU, Memory, Disk) - identical to the main server list.
+
+## Installation
+
+1. Download the latest release ZIP file from the [Releases](https://github.com/FlexKleks/PelicanPlugins/releases) page
+2. Go to your Pelican Panel admin area
+3. Navigate to **Admin → Plugins**
+4. Click **"Import file"**
+5. Select the downloaded ZIP file
+6. Click **"Import"**
+
+### Database Migration
+
+After installing the plugin, run the database migration:
+
+```bash
+cd /var/www/pelican
+php artisan migrate
+```
+
+This creates the necessary database tables:
+- `server_folders` - Stores folder information (name, color, user, sharing settings)
+- `server_folder_server` - Links servers to folders (many-to-many relationship)
+- `server_folder_role` - Links folders to roles for sharing (many-to-many relationship)
+
+### Clear Cache
+
+After installation, clear the application cache:
+
+```bash
+php artisan optimize:clear
+php artisan view:clear
+```
+
+## Usage
+
+### Creating a Folder
+
+1. Navigate to **Folders** in the sidebar
+2. Click **"Create Folder"**
+3. Enter a folder name and optionally select a color
+4. Click **"Create"**
+
+### Adding Servers to a Folder
+
+1. Open a folder by clicking on it
+2. Click **"Add Server"** in the top right
+3. Select a server from the dropdown
+4. The server will be added to the folder
+
+### Removing Servers from a Folder
+
+1. Open the folder containing the server
+2. Hover over the server row
+3. Click the folder-minus icon that appears on the right
+4. Confirm the removal
+
+### Editing a Folder
+
+1. Open the folder
+2. Click **"Edit"** in the top right
+3. Modify the name or color
+4. Click **"Save"**
+
+### Sharing a Folder with Roles
+
+1. Open the folder you want to share
+2. Click **"Edit"** in the top right
+3. Enable **"Share Folder"**
+4. Select the roles that should have access
+5. Click **"Save"**
+
+Users with the selected roles will now see this folder in their sidebar and can view the servers inside. Only the folder owner can edit or delete the folder.
+
+### Deleting a Folder
+
+1. Open the folder
+2. Click **"Delete"** in the top right
+3. Confirm the deletion
+
+> **Note:** Deleting a folder does NOT delete the servers inside it. Servers are only unlinked from the folder.
+
+## Server Display
+
+The folder view displays servers in a table format identical to the main server list:
+
+| Column | Description |
+|--------|-------------|
+| Icon | Server/Egg icon |
+| Status | Running, Offline, Starting, etc. with colored badge |
+| Name | Server name and description |
+| Address | Server IP:Port |
+| CPU | CPU usage with progress bar |
+| Memory | Memory usage with progress bar |
+| Disk | Disk usage with progress bar |
+
+- **Green** progress bar: Usage below 70%
+- **Yellow** progress bar: Usage between 70-90%
+- **Red** progress bar: Usage above 90%
+
+Stats update automatically every 15 seconds.
+
+## Permissions
+
+- Users can create and manage their own folders
+- Users can only add servers they have access to
+- Folder owners can share folders with specific roles
+- Users with matching roles can view shared folders (read-only)
+- Only the folder owner can edit, delete, or add/remove servers
+
+### Shared Folder Icons
+
+- 📁 **Filled folder** - Your own folder
+- 📂 **Shared folder** - Folder shared with you by another user
+
+## File Structure
+
+```
+server-folders/
+├── config/
+│   └── server-folders.php
+├── database/
+│   └── migrations/
+│       ├── 2024_12_27_000001_create_server_folders_table.php
+│       └── 2024_12_27_000002_add_shared_roles_to_server_folders.php
+├── lang/
+│   ├── en/
+│   │   └── messages.php
+│   └── de/
+│       └── messages.php
+├── resources/
+│   └── views/
+│       └── view-folder.blade.php
+├── src/
+│   ├── Filament/
+│   │   └── App/
+│   │       └── Resources/
+│   │           └── ServerFolders/
+│   │               ├── Pages/
+│   │               │   ├── ManageServerFolders.php
+│   │               │   └── ViewServerFolder.php
+│   │               └── ServerFolderResource.php
+│   ├── Models/
+│   │   └── ServerFolder.php
+│   └── ServerFoldersPlugin.php
+├── plugin.json
+└── README.md
+```
+
+## Requirements
+
+- Pelican Panel 1.0+
+- PHP 8.2+
+- MySQL/MariaDB
+
+## Troubleshooting
+
+### Folders not showing in sidebar
+Run `php artisan optimize:clear` and refresh the page.
+
+### Database errors
+Make sure you ran `php artisan migrate` after installing the plugin.
+
+### Servers not displaying correctly
+Run `php artisan view:clear` to clear cached views.
+
+### Shared folders not visible
+Make sure the user has a role that was selected when sharing the folder.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This plugin is open-sourced software licensed under the [MIT license](LICENSE).
+
+## Author
+
+Created by [FlexKleks](https://github.com/FlexKleks)
+
+## Support
+
+- [GitHub Issues](https://github.com/FlexKleks/PelicanPlugins/issues)
+- [Pelican Discord](https://discord.gg/pelican-panel)

--- a/server-folders/database/migrations/2024_12_27_000001_create_server_folders_table.php
+++ b/server-folders/database/migrations/2024_12_27_000001_create_server_folders_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('server_folders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('color')->nullable();
+            $table->string('icon')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('server_folder_server', function (Blueprint $table) {
+            $table->foreignId('folder_id')->constrained('server_folders')->cascadeOnDelete();
+            $table->foreignId('server_id')->constrained()->cascadeOnDelete();
+            $table->primary(['folder_id', 'server_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('server_folder_server');
+        Schema::dropIfExists('server_folders');
+    }
+};

--- a/server-folders/database/migrations/2024_12_27_000002_add_shared_roles_to_server_folders.php
+++ b/server-folders/database/migrations/2024_12_27_000002_add_shared_roles_to_server_folders.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('server_folders', function (Blueprint $table) {
+            $table->boolean('is_shared')->default(false)->after('sort_order');
+        });
+
+        Schema::create('server_folder_role', function (Blueprint $table) {
+            $table->foreignId('folder_id')->constrained('server_folders')->cascadeOnDelete();
+            $table->foreignId('role_id')->constrained('roles')->cascadeOnDelete();
+            $table->primary(['folder_id', 'role_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('server_folder_role');
+
+        Schema::table('server_folders', function (Blueprint $table) {
+            $table->dropColumn('is_shared');
+        });
+    }
+};

--- a/server-folders/lang/de/messages.php
+++ b/server-folders/lang/de/messages.php
@@ -1,0 +1,64 @@
+<?php
+
+return [
+    // Navigation & Titles
+    'folder' => 'Ordner',
+    'folders' => 'Ordner',
+    'folder_name' => 'Ordnername',
+    'color' => 'Farbe',
+    'color_hint' => 'Wähle eine Farbe zur Kennzeichnung in der Seitenleiste',
+
+    // Table Headers
+    'servers' => 'Server',
+    'server_name' => 'Server',
+    'address' => 'Adresse',
+    'node' => 'Node',
+    'status' => 'Status',
+    'cpu' => 'CPU',
+    'memory' => 'Arbeitsspeicher',
+    'disk' => 'Speicher',
+    'shared' => 'Geteilt',
+    'owner' => 'Besitzer',
+
+    // Actions
+    'add_server' => 'Server hinzufügen',
+    'select_server' => 'Server auswählen',
+    'edit' => 'Bearbeiten',
+    'remove' => 'Entfernen',
+    'delete' => 'Löschen',
+    'create_folder' => 'Ordner erstellen',
+    'save' => 'Speichern',
+    'cancel' => 'Abbrechen',
+
+    // Sharing
+    'share_folder' => 'Ordner teilen',
+    'share_folder_hint' => 'Erlaube Benutzern mit bestimmten Rollen, diesen Ordner zu sehen',
+    'shared_with_roles' => 'Mit Rollen teilen',
+    'shared_with_roles_hint' => 'Wähle aus, welche Rollen diesen Ordner und seine Server sehen können',
+    'shared_folder' => 'Geteilter Ordner',
+    'private_folder' => 'Privater Ordner',
+
+    // Empty States
+    'no_folders' => 'Noch keine Ordner',
+    'no_folders_desc' => 'Erstelle deinen ersten Ordner, um deine Server zu organisieren.',
+    'no_servers_in_folder' => 'Dieser Ordner ist leer',
+    'no_servers_desc' => 'Klicke oben auf "Server hinzufügen", um Server hinzuzufügen.',
+    'no_available_servers' => 'Keine Server zum Hinzufügen verfügbar',
+
+    // Notifications
+    'folder_created' => 'Ordner erfolgreich erstellt',
+    'folder_updated' => 'Ordner erfolgreich aktualisiert',
+    'folder_deleted' => 'Ordner erfolgreich gelöscht',
+    'server_added' => 'Server zum Ordner hinzugefügt',
+    'server_removed' => 'Server aus Ordner entfernt',
+    'no_permission' => 'Du hast keine Berechtigung dafür',
+
+    // Confirmations
+    'confirm_remove' => 'Möchtest du diesen Server wirklich aus dem Ordner entfernen?',
+    'confirm_delete' => 'Möchtest du diesen Ordner wirklich löschen? Server werden nicht gelöscht.',
+
+    // Tooltips
+    'remove_from_folder' => 'Aus Ordner entfernen',
+    'view_folder' => 'Ordnerinhalt anzeigen',
+    'server_count' => ':count Server',
+];

--- a/server-folders/lang/en/messages.php
+++ b/server-folders/lang/en/messages.php
@@ -1,0 +1,64 @@
+<?php
+
+return [
+    // Navigation & Titles
+    'folder' => 'Folder',
+    'folders' => 'Folders',
+    'folder_name' => 'Folder Name',
+    'color' => 'Color',
+    'color_hint' => 'Choose a color to identify this folder in the sidebar',
+
+    // Table Headers
+    'servers' => 'Servers',
+    'server_name' => 'Server',
+    'address' => 'Address',
+    'node' => 'Node',
+    'status' => 'Status',
+    'cpu' => 'CPU',
+    'memory' => 'Memory',
+    'disk' => 'Disk',
+    'shared' => 'Shared',
+    'owner' => 'Owner',
+
+    // Actions
+    'add_server' => 'Add Server',
+    'select_server' => 'Select Server',
+    'edit' => 'Edit',
+    'remove' => 'Remove',
+    'delete' => 'Delete',
+    'create_folder' => 'Create Folder',
+    'save' => 'Save',
+    'cancel' => 'Cancel',
+
+    // Sharing
+    'share_folder' => 'Share Folder',
+    'share_folder_hint' => 'Allow users with specific roles to view this folder',
+    'shared_with_roles' => 'Share with Roles',
+    'shared_with_roles_hint' => 'Select which roles can view this folder and its servers',
+    'shared_folder' => 'Shared Folder',
+    'private_folder' => 'Private Folder',
+
+    // Empty States
+    'no_folders' => 'No folders yet',
+    'no_folders_desc' => 'Create your first folder to organize your servers into groups.',
+    'no_servers_in_folder' => 'This folder is empty',
+    'no_servers_desc' => 'Click "Add Server" above to add servers to this folder.',
+    'no_available_servers' => 'No servers available to add',
+
+    // Notifications
+    'folder_created' => 'Folder created successfully',
+    'folder_updated' => 'Folder updated successfully',
+    'folder_deleted' => 'Folder deleted successfully',
+    'server_added' => 'Server added to folder',
+    'server_removed' => 'Server removed from folder',
+    'no_permission' => 'You do not have permission to do this',
+
+    // Confirmations
+    'confirm_remove' => 'Are you sure you want to remove this server from the folder?',
+    'confirm_delete' => 'Are you sure you want to delete this folder? Servers will not be deleted.',
+
+    // Tooltips
+    'remove_from_folder' => 'Remove from folder',
+    'view_folder' => 'View folder contents',
+    'server_count' => ':count server|:count servers',
+];

--- a/server-folders/plugin.json
+++ b/server-folders/plugin.json
@@ -1,0 +1,15 @@
+{
+    "id": "server-folders",
+    "name": "Server Folders",
+    "author": "FlexKleks",
+    "version": "1.0.0",
+    "description": "Organize servers into folders",
+    "category": "plugin",
+    "url": "https://github.com/FlexKleks/PelicanPlugins",
+    "update_url": null,
+    "namespace": "FlexKleks\\ServerFolders",
+    "class": "ServerFoldersPlugin",
+    "panels": ["app"],
+    "panel_version": null,
+    "composer_packages": null
+}

--- a/server-folders/resources/views/view-folder.blade.php
+++ b/server-folders/resources/views/view-folder.blade.php
@@ -1,0 +1,149 @@
+@php
+    $servers = $this->getServers();
+@endphp
+
+<x-filament-panels::page>
+    @if($servers->count() > 0)
+        <div class="fi-ta">
+            <div class="fi-ta-content rounded-xl bg-white ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10 overflow-x-auto">
+                <table class="fi-ta-table w-full table-auto divide-y divide-gray-200 dark:divide-white/5 text-start">
+                    <tbody class="divide-y divide-gray-200 dark:divide-white/5" wire:poll.15s>
+                        @foreach($servers as $server)
+                            @php
+                                $resources = $server->retrieveResources();
+                                $nodeStats = $server->node->statistics();
+                                $nodeInfo = $server->node->systemInformation();
+                                
+                                // CPU
+                                $cpuCurrent = $resources['cpu_absolute'] ?? 0;
+                                $cpuLimit = $server->cpu === 0 ? (($nodeInfo['cpu_count'] ?? 1) * 100) : $server->cpu;
+                                $cpuPercent = $cpuLimit > 0 ? min(($cpuCurrent / $cpuLimit) * 100, 100) : 0;
+                                
+                                // Memory
+                                $memCurrent = $resources['memory_bytes'] ?? 0;
+                                $memLimit = $server->memory === 0 ? ($nodeStats['memory_total'] ?? 0) : ($server->memory * 1024 * 1024);
+                                $memPercent = $memLimit > 0 ? min(($memCurrent / $memLimit) * 100, 100) : 0;
+                                
+                                // Disk
+                                $diskCurrent = $resources['disk_bytes'] ?? 0;
+                                $diskLimit = $server->disk === 0 ? ($nodeStats['disk_total'] ?? 0) : ($server->disk * 1024 * 1024);
+                                $diskPercent = $diskLimit > 0 ? min(($diskCurrent / $diskLimit) * 100, 100) : 0;
+                                
+                                // Helper function for color
+                                $getColor = function($percent) {
+                                    if ($percent >= 90) return '#ef4444';
+                                    if ($percent >= 70) return '#f59e0b';
+                                    return '#22c55e';
+                                };
+                                
+                                // Format bytes
+                                $formatBytes = function($bytes) {
+                                    if ($bytes >= 1073741824) return number_format($bytes / 1073741824, 2) . ' GB';
+                                    if ($bytes >= 1048576) return number_format($bytes / 1048576, 2) . ' MB';
+                                    if ($bytes >= 1024) return number_format($bytes / 1024, 2) . ' KB';
+                                    return $bytes . ' Bytes';
+                                };
+                                
+                                $formatLimit = function($mb) use ($formatBytes, $nodeStats) {
+                                    if ($mb === 0) return '∞';
+                                    return $formatBytes($mb * 1024 * 1024);
+                                };
+                            @endphp
+                            <tr class="fi-ta-row transition hover:bg-gray-50 dark:hover:bg-white/5 cursor-pointer group"
+                                onclick="window.location='{{ route('filament.server.pages.console', ['tenant' => $server]) }}'">
+                                {{-- Icon --}}
+                                <td class="fi-ta-cell p-3" style="width: 60px;">
+                                    @if($server->icon ?? $server->egg?->image)
+                                        <img src="{{ $server->icon ?? $server->egg->image }}" alt="" class="w-11 h-11 rounded object-cover">
+                                    @endif
+                                </td>
+                                
+                                {{-- Status Badge --}}
+                                <td class="fi-ta-cell p-3" style="width: 100px;">
+                                    <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium"
+                                          style="background-color: color-mix(in srgb, {{ $server->condition->getColor(true) }} 15%, transparent); color: {{ $server->condition->getColor(true) }};">
+                                        <x-filament::icon :icon="$server->condition->getIcon()" class="w-4 h-4" />
+                                        {{ $server->condition->getLabel() }}
+                                    </span>
+                                </td>
+                                
+                                {{-- Name --}}
+                                <td class="fi-ta-cell p-3">
+                                    <div class="font-medium text-gray-950 dark:text-white">{{ $server->name }}</div>
+                                    @if($server->description)
+                                        <div class="text-sm text-gray-500 dark:text-gray-400">{{ Str::limit($server->description, 40) }}</div>
+                                    @endif
+                                </td>
+                                
+                                {{-- Address --}}
+                                <td class="fi-ta-cell p-3 hidden md:table-cell" style="width: 140px;">
+                                    <span class="inline-flex items-center rounded-md bg-primary-50 dark:bg-primary-400/10 px-2 py-1 text-xs font-medium text-primary-700 dark:text-primary-400 ring-1 ring-inset ring-primary-700/10 dark:ring-primary-400/30">
+                                        {{ $server->allocation?->address }}
+                                    </span>
+                                </td>
+                                
+                                {{-- CPU --}}
+                                <td class="fi-ta-cell p-3 hidden lg:table-cell" style="width: 130px;">
+                                    <div class="flex flex-col gap-1">
+                                        <div class="relative rounded-full overflow-hidden w-full h-2" style="background-color: color-mix(in srgb, {{ $getColor($cpuPercent) }} 15%, transparent);">
+                                            <div class="h-full rounded-full" style="width: {{ $cpuPercent }}%; background-color: {{ $getColor($cpuPercent) }};"></div>
+                                        </div>
+                                        <span class="text-xs text-gray-500 dark:text-gray-400 text-center">
+                                            {{ number_format($cpuCurrent, 0) }}% / {{ $server->cpu === 0 ? '∞' : $server->cpu . '%' }}
+                                        </span>
+                                    </div>
+                                </td>
+                                
+                                {{-- Memory --}}
+                                <td class="fi-ta-cell p-3 hidden lg:table-cell" style="width: 150px;">
+                                    <div class="flex flex-col gap-1">
+                                        <div class="relative rounded-full overflow-hidden w-full h-2" style="background-color: color-mix(in srgb, {{ $getColor($memPercent) }} 15%, transparent);">
+                                            <div class="h-full rounded-full" style="width: {{ $memPercent }}%; background-color: {{ $getColor($memPercent) }};"></div>
+                                        </div>
+                                        <span class="text-xs text-gray-500 dark:text-gray-400 text-center">
+                                            {{ $formatBytes($memCurrent) }} / {{ $server->memory === 0 ? '∞' : $formatBytes($server->memory * 1024 * 1024) }}
+                                        </span>
+                                    </div>
+                                </td>
+                                
+                                {{-- Disk --}}
+                                <td class="fi-ta-cell p-3 hidden xl:table-cell" style="width: 150px;">
+                                    <div class="flex flex-col gap-1">
+                                        <div class="relative rounded-full overflow-hidden w-full h-2" style="background-color: color-mix(in srgb, {{ $getColor($diskPercent) }} 15%, transparent);">
+                                            <div class="h-full rounded-full" style="width: {{ $diskPercent }}%; background-color: {{ $getColor($diskPercent) }};"></div>
+                                        </div>
+                                        <span class="text-xs text-gray-500 dark:text-gray-400 text-center">
+                                            {{ $formatBytes($diskCurrent) }} / {{ $server->disk === 0 ? '∞' : $formatBytes($server->disk * 1024 * 1024) }}
+                                        </span>
+                                    </div>
+                                </td>
+                                
+                                {{-- Remove Button --}}
+                                <td class="fi-ta-cell p-3 text-end" style="width: 50px;" onclick="event.stopPropagation()">
+                                    <button type="button"
+                                            wire:click="removeServer({{ $server->id }})"
+                                            wire:confirm="{{ trans('server-folders::messages.confirm_remove') }}"
+                                            class="opacity-0 group-hover:opacity-100 inline-flex items-center justify-center rounded-lg p-2 text-gray-400 hover:text-danger-500 hover:bg-danger-50 dark:hover:bg-danger-500/10 transition">
+                                        <x-filament::icon icon="tabler-folder-minus" class="w-5 h-5" />
+                                    </button>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    @else
+        <div class="flex flex-col items-center justify-center py-12 text-center">
+            <div class="rounded-full bg-gray-100 dark:bg-gray-800 p-4 mb-4">
+                <x-filament::icon icon="tabler-folder-open" class="w-12 h-12 text-gray-400" />
+            </div>
+            <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-1">
+                {{ trans('server-folders::messages.no_servers_in_folder') }}
+            </h3>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+                {{ trans('server-folders::messages.no_servers_desc') }}
+            </p>
+        </div>
+    @endif
+</x-filament-panels::page>

--- a/server-folders/src/Filament/App/Resources/ServerFolders/Pages/ManageServerFolders.php
+++ b/server-folders/src/Filament/App/Resources/ServerFolders/Pages/ManageServerFolders.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FlexKleks\ServerFolders\Filament\App\Resources\ServerFolders\Pages;
+
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+use FlexKleks\ServerFolders\Filament\App\Resources\ServerFolders\ServerFolderResource;
+
+class ManageServerFolders extends ManageRecords
+{
+    protected static string $resource = ServerFolderResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make()
+                ->mutateFormDataUsing(function (array $data): array {
+                    $data['user_id'] = auth()->id();
+
+                    return $data;
+                }),
+        ];
+    }
+}

--- a/server-folders/src/Filament/App/Resources/ServerFolders/Pages/ViewServerFolder.php
+++ b/server-folders/src/Filament/App/Resources/ServerFolders/Pages/ViewServerFolder.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace FlexKleks\ServerFolders\Filament\App\Resources\ServerFolders\Pages;
+
+use App\Models\Role;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Forms\Components\ColorPicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\Concerns\InteractsWithRecord;
+use Filament\Resources\Pages\Page;
+use FlexKleks\ServerFolders\Filament\App\Resources\ServerFolders\ServerFolderResource;
+use Illuminate\Contracts\Support\Htmlable;
+
+class ViewServerFolder extends Page
+{
+    use InteractsWithRecord;
+
+    protected static string $resource = ServerFolderResource::class;
+
+    protected string $view = 'server-folders::view-folder';
+
+    public function mount(int|string $record): void
+    {
+        $this->record = $this->resolveRecord($record);
+
+        abort_unless($this->record->isVisibleTo(auth()->user()), 403);
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        return $this->record->name;
+    }
+
+    public function getBreadcrumb(): string
+    {
+        return $this->record->name;
+    }
+
+    public function isOwner(): bool
+    {
+        return $this->record->isEditableBy(auth()->user());
+    }
+
+    public function getServers()
+    {
+        return $this->record->servers()->with(['egg', 'node', 'allocation'])->get();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        $actions = [];
+
+        // Only owner can add servers
+        if ($this->isOwner()) {
+            $actions[] = Action::make('addServer')
+                ->label(trans('server-folders::messages.add_server'))
+                ->icon('tabler-plus')
+                ->form([
+                    Select::make('server_id')
+                        ->label(trans('server-folders::messages.select_server'))
+                        ->options(function () {
+                            $existingIds = $this->record->servers->pluck('id')->toArray();
+
+                            return auth()->user()->accessibleServers()
+                                ->whereNotIn('servers.id', $existingIds)
+                                ->pluck('servers.name', 'servers.id');
+                        })
+                        ->searchable()
+                        ->required(),
+                ])
+                ->action(function (array $data) {
+                    $this->record->servers()->attach($data['server_id']);
+
+                    Notification::make()
+                        ->title(trans('server-folders::messages.server_added'))
+                        ->success()
+                        ->send();
+                });
+
+            $actions[] = Action::make('edit')
+                ->label(trans('server-folders::messages.edit'))
+                ->icon('tabler-pencil')
+                ->color('gray')
+                ->form([
+                    TextInput::make('name')
+                        ->label(trans('server-folders::messages.folder_name'))
+                        ->required()
+                        ->maxLength(50)
+                        ->default(fn () => $this->record->name),
+                    ColorPicker::make('color')
+                        ->label(trans('server-folders::messages.color'))
+                        ->default(fn () => $this->record->color),
+                    Toggle::make('is_shared')
+                        ->label(trans('server-folders::messages.share_folder'))
+                        ->helperText(trans('server-folders::messages.share_folder_hint'))
+                        ->default(fn () => $this->record->is_shared)
+                        ->live(),
+                    Select::make('roles')
+                        ->label(trans('server-folders::messages.shared_with_roles'))
+                        ->helperText(trans('server-folders::messages.shared_with_roles_hint'))
+                        ->multiple()
+                        ->options(Role::pluck('name', 'id'))
+                        ->default(fn () => $this->record->roles->pluck('id')->toArray())
+                        ->searchable()
+                        ->preload()
+                        ->visible(fn ($get) => $get('is_shared')),
+                ])
+                ->action(function (array $data) {
+                    $this->record->update([
+                        'name' => $data['name'],
+                        'color' => $data['color'],
+                        'is_shared' => $data['is_shared'] ?? false,
+                    ]);
+
+                    if ($data['is_shared'] ?? false) {
+                        $this->record->roles()->sync($data['roles'] ?? []);
+                    } else {
+                        $this->record->roles()->detach();
+                    }
+
+                    Notification::make()
+                        ->title(trans('server-folders::messages.folder_updated'))
+                        ->success()
+                        ->send();
+                });
+
+            $actions[] = DeleteAction::make()
+                ->record($this->record)
+                ->successRedirectUrl(ServerFolderResource::getUrl());
+        }
+
+        return $actions;
+    }
+
+    public function removeServer(int $serverId): void
+    {
+        // Only owner can remove servers
+        if (!$this->isOwner()) {
+            Notification::make()
+                ->title(trans('server-folders::messages.no_permission'))
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $this->record->servers()->detach($serverId);
+
+        Notification::make()
+            ->title(trans('server-folders::messages.server_removed'))
+            ->success()
+            ->send();
+    }
+}

--- a/server-folders/src/Filament/App/Resources/ServerFolders/ServerFolderResource.php
+++ b/server-folders/src/Filament/App/Resources/ServerFolders/ServerFolderResource.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace FlexKleks\ServerFolders\Filament\App\Resources\ServerFolders;
+
+use App\Models\Role;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\ColorPicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Navigation\NavigationItem;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\ColorColumn;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use FlexKleks\ServerFolders\Filament\App\Resources\ServerFolders\Pages\ManageServerFolders;
+use FlexKleks\ServerFolders\Filament\App\Resources\ServerFolders\Pages\ViewServerFolder;
+use FlexKleks\ServerFolders\Models\ServerFolder;
+use Illuminate\Database\Eloquent\Builder;
+
+class ServerFolderResource extends Resource
+{
+    protected static ?string $model = ServerFolder::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'tabler-folder';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function getNavigationLabel(): string
+    {
+        return trans('server-folders::messages.folders');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return trans('server-folders::messages.folder');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return trans('server-folders::messages.folders');
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getEloquentQuery()->count() ?: null;
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->visibleTo(auth()->user());
+    }
+
+    public static function getNavigationItems(): array
+    {
+        $items = parent::getNavigationItems();
+
+        // Add folder items to navigation
+        if (auth()->check()) {
+            $folders = ServerFolder::visibleTo(auth()->user())
+                ->withCount('servers')
+                ->orderBy('sort_order')
+                ->get();
+
+            foreach ($folders as $folder) {
+                $isOwner = $folder->user_id === auth()->id();
+
+                $items[] = NavigationItem::make($folder->name)
+                    ->icon($folder->is_shared && !$isOwner ? 'tabler-folder-share' : 'tabler-folder-filled')
+                    ->badge($folder->servers_count ?: null)
+                    ->url(static::getUrl('view', ['record' => $folder]))
+                    ->isActiveWhen(fn () => request()->route('record') == $folder->id)
+                    ->sort(10 + $folder->sort_order);
+            }
+        }
+
+        return $items;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                ColorColumn::make('color')
+                    ->label('')
+                    ->width('40px'),
+                TextColumn::make('name')
+                    ->label(trans('server-folders::messages.folder_name'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('servers_count')
+                    ->label(trans('server-folders::messages.servers'))
+                    ->counts('servers')
+                    ->badge()
+                    ->color('gray'),
+                IconColumn::make('is_shared')
+                    ->label(trans('server-folders::messages.shared'))
+                    ->boolean()
+                    ->trueIcon('tabler-share')
+                    ->falseIcon('tabler-lock')
+                    ->trueColor('success')
+                    ->falseColor('gray'),
+                TextColumn::make('user.username')
+                    ->label(trans('server-folders::messages.owner'))
+                    ->visible(fn () => ServerFolder::visibleTo(auth()->user())->where('user_id', '!=', auth()->id())->exists()),
+            ])
+            ->defaultSort('sort_order')
+            ->reorderable('sort_order')
+            ->recordUrl(fn (ServerFolder $record) => static::getUrl('view', ['record' => $record]))
+            ->recordActions([
+                ActionGroup::make([
+                    ViewAction::make(),
+                    EditAction::make()
+                        ->visible(fn (ServerFolder $record) => $record->isEditableBy(auth()->user())),
+                    DeleteAction::make()
+                        ->visible(fn (ServerFolder $record) => $record->isEditableBy(auth()->user())),
+                ]),
+            ])
+            ->emptyStateIcon('tabler-folder')
+            ->emptyStateDescription(trans('server-folders::messages.no_folders_desc'))
+            ->emptyStateHeading(trans('server-folders::messages.no_folders'));
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->label(trans('server-folders::messages.folder_name'))
+                    ->required()
+                    ->maxLength(50),
+                ColorPicker::make('color')
+                    ->label(trans('server-folders::messages.color')),
+                Toggle::make('is_shared')
+                    ->label(trans('server-folders::messages.share_folder'))
+                    ->helperText(trans('server-folders::messages.share_folder_hint'))
+                    ->live(),
+                Select::make('roles')
+                    ->label(trans('server-folders::messages.shared_with_roles'))
+                    ->helperText(trans('server-folders::messages.shared_with_roles_hint'))
+                    ->multiple()
+                    ->relationship('roles', 'name')
+                    ->options(Role::pluck('name', 'id'))
+                    ->searchable()
+                    ->preload()
+                    ->visible(fn ($get) => $get('is_shared')),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ManageServerFolders::route('/'),
+            'view' => ViewServerFolder::route('/{record}'),
+        ];
+    }
+}

--- a/server-folders/src/Filament/Server/Components/AddToFolderAction.php
+++ b/server-folders/src/Filament/Server/Components/AddToFolderAction.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace FlexKleks\ServerFolders\Filament\Server\Components;
+
+use App\Models\Server;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
+use FlexKleks\ServerFolders\Models\ServerFolder;
+
+class AddToFolderAction extends Action
+{
+    public static function getDefaultName(): ?string
+    {
+        return 'add_to_folder';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label(fn () => trans('server-folders::messages.move_to_folder'));
+
+        $this->icon('tabler-folder');
+
+        $this->color('gray');
+
+        $this->form([
+            Select::make('folder_id')
+                ->label(trans('server-folders::messages.select_folder'))
+                ->options(fn () => ServerFolder::where('user_id', auth()->id())->pluck('name', 'id'))
+                ->searchable()
+                ->required(),
+        ]);
+
+        $this->action(function (array $data) {
+            /** @var Server $server */
+            $server = Filament::getTenant();
+
+            $folder = ServerFolder::where('user_id', auth()->id())
+                ->find($data['folder_id']);
+
+            if ($folder) {
+                // Remove from other folders first
+                ServerFolder::where('user_id', auth()->id())
+                    ->get()
+                    ->each(fn ($f) => $f->servers()->detach($server->id));
+
+                // Add to selected folder
+                $folder->servers()->attach($server->id);
+
+                Notification::make()
+                    ->title(trans('server-folders::messages.server_added'))
+                    ->success()
+                    ->send();
+            }
+        });
+    }
+}

--- a/server-folders/src/Models/ServerFolder.php
+++ b/server-folders/src/Models/ServerFolder.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace FlexKleks\ServerFolders\Models;
+
+use App\Models\Role;
+use App\Models\Server;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class ServerFolder extends Model
+{
+    protected $table = 'server_folders';
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'color',
+        'icon',
+        'sort_order',
+        'is_shared',
+    ];
+
+    protected $casts = [
+        'sort_order' => 'integer',
+        'is_shared' => 'boolean',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function servers(): BelongsToMany
+    {
+        return $this->belongsToMany(Server::class, 'server_folder_server', 'folder_id', 'server_id');
+    }
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'server_folder_role', 'folder_id', 'role_id');
+    }
+
+    /**
+     * Scope to get folders visible to a user (own folders + shared folders with matching roles)
+     */
+    public function scopeVisibleTo(Builder $query, User $user): Builder
+    {
+        return $query->where(function ($q) use ($user) {
+            // User's own folders
+            $q->where('user_id', $user->id)
+                // OR shared folders where user has a matching role
+                ->orWhere(function ($q2) use ($user) {
+                    $q2->where('is_shared', true)
+                        ->whereHas('roles', function ($q3) use ($user) {
+                            $q3->whereIn('roles.id', $user->roles->pluck('id'));
+                        });
+                });
+        });
+    }
+
+    /**
+     * Check if a user can view this folder
+     */
+    public function isVisibleTo(User $user): bool
+    {
+        // Owner can always see
+        if ($this->user_id === $user->id) {
+            return true;
+        }
+
+        // Check if shared and user has matching role
+        if ($this->is_shared) {
+            $userRoleIds = $user->roles->pluck('id')->toArray();
+            $folderRoleIds = $this->roles->pluck('id')->toArray();
+
+            return count(array_intersect($userRoleIds, $folderRoleIds)) > 0;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a user can edit this folder (only owner)
+     */
+    public function isEditableBy(User $user): bool
+    {
+        return $this->user_id === $user->id;
+    }
+}

--- a/server-folders/src/Providers/ServerFoldersPluginProvider.php
+++ b/server-folders/src/Providers/ServerFoldersPluginProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FlexKleks\ServerFolders\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class ServerFoldersPluginProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        //
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/server-folders/src/ServerFoldersPlugin.php
+++ b/server-folders/src/ServerFoldersPlugin.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FlexKleks\ServerFolders;
+
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+
+class ServerFoldersPlugin implements Plugin
+{
+    public function getId(): string
+    {
+        return 'server-folders';
+    }
+
+    public function register(Panel $panel): void
+    {
+        if ($panel->getId() === 'app') {
+            $panel->navigation(true);
+        }
+
+        $id = str($panel->getId())->title();
+
+        $panel->discoverResources(
+            plugin_path($this->getId(), "src/Filament/$id/Resources"),
+            "FlexKleks\\ServerFolders\\Filament\\$id\\Resources"
+        );
+    }
+
+    public function boot(Panel $panel): void
+    {
+        //
+    }
+}


### PR DESCRIPTION
Adds Server Folders plugin - allows users to organize servers into custom folders with role-based sharing.

## Features

- Create custom folders with color coding
- Role-based sharing (share folders with specific user roles)
- Live resource monitoring (CPU, Memory, Disk) with 15s auto-refresh
- Sidebar navigation with server count badges
- Multi-language support (English & German)

## Configuration

Requires database migration after installation:
```bash
php artisan migrate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server Folders: Organize and group your servers into custom folders for better management
  * Share folders with role-based access control
  * Monitor dynamic server resource metrics (CPU, memory, disk) within folders
  * Add and remove servers from folders with action buttons

* **Documentation**
  * Added comprehensive Server Folders plugin documentation with installation and usage guides

* **Localization**
  * Added German language support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->