### PR TITLE
Drop user created server's resource entry minimum limit to 0

### DIFF
--- a/user-creatable-servers/src/Filament/Components/Actions/CreateServerAction.php
+++ b/user-creatable-servers/src/Filament/Components/Actions/CreateServerAction.php
@@ -59,21 +59,21 @@ class CreateServerAction extends Action
                     ->label(trans('user-creatable-servers::strings.cpu'))
                     ->required()
                     ->numeric()
-                    ->minValue(0)
+                    ->minValue($userResourceLimits->cpu > 0 ? 1 : 0)
                     ->maxValue($userResourceLimits->getCpuLeft())
                     ->suffix('%'),
                 TextInput::make('memory')
                     ->label(trans('user-creatable-servers::strings.memory'))
                     ->required()
                     ->numeric()
-                    ->minValue(0)
+                    ->minValue($userResourceLimits->memory > 0 ? 1 : 0)
                     ->maxValue($userResourceLimits->getMemoryLeft())
                     ->suffix(config('panel.use_binary_prefix') ? 'MiB' : 'MB'),
                 TextInput::make('disk')
                     ->label(trans('user-creatable-servers::strings.disk'))
                     ->required()
                     ->numeric()
-                    ->minValue(0)
+                    ->minValue($userResourceLimits->disk > 0 ? 1 : 0)
                     ->maxValue($userResourceLimits->getDiskLeft())
                     ->suffix(config('panel.use_binary_prefix') ? 'MiB' : 'MB'),
             ];

--- a/user-creatable-servers/src/Filament/Server/Pages/ServerResourcePage.php
+++ b/user-creatable-servers/src/Filament/Server/Pages/ServerResourcePage.php
@@ -69,7 +69,7 @@ class ServerResourcePage extends ServerFormPage
                     ->hint(fn ($state) => $userResourceLimits->cpu > 0 ? ($maxCpu - $state . '% ' . trans('user-creatable-servers::strings.left')) : trans('user-creatable-servers::strings.unlimited'))
                     ->hintColor(fn ($state) => $userResourceLimits->cpu > 0 && $maxCpu - $state < 0 ? 'danger' : null)
                     ->numeric()
-                    ->minValue(0)
+                    ->minValue($userResourceLimits->cpu > 0 ? 1 : 0)
                     ->maxValue($userResourceLimits->cpu > 0 ? $maxCpu : null)
                     ->suffix('%'),
                 TextInput::make('memory')
@@ -79,7 +79,7 @@ class ServerResourcePage extends ServerFormPage
                     ->hint(fn ($state) => $userResourceLimits->memory > 0 ? ($maxMemory - $state . $suffix . ' ' . trans('user-creatable-servers::strings.left')) : trans('user-creatable-servers::strings.unlimited'))
                     ->hintColor(fn ($state) => $userResourceLimits->memory > 0 && $maxMemory - $state < 0 ? 'danger' : null)
                     ->numeric()
-                    ->minValue(0)
+                    ->minValue($userResourceLimits->memory > 0 ? 1 : 0)
                     ->maxValue($userResourceLimits->memory > 0 ? $maxMemory : null)
                     ->suffix($suffix),
                 TextInput::make('disk')
@@ -89,7 +89,7 @@ class ServerResourcePage extends ServerFormPage
                     ->hint(fn ($state) => $userResourceLimits->disk > 0 ? ($maxDisk - $state . $suffix . ' ' . trans('user-creatable-servers::strings.left')) : trans('user-creatable-servers::strings.unlimited'))
                     ->hintColor(fn ($state) => $userResourceLimits->disk > 0 && $maxDisk - $state < 0 ? 'danger' : null)
                     ->numeric()
-                    ->minValue(0)
+                    ->minValue($userResourceLimits->disk > 0 ? 1 : 0)
                     ->maxValue($userResourceLimits->disk > 0 ? $maxDisk : null)
                     ->suffix($suffix),
             ]);


### PR DESCRIPTION
The rest of the code is already set up to treat 0 as "unlimited", as far as I can tell, but the UI elements were limiting the minimum to 1.  This change allows users to specify unlimited resources for a specific server if the user is not globally limited in that resource.  I've tested this on my local Pelican instance, and it works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated server resource input validation: CPU, memory, and disk fields can now accept zero when a user has no corresponding resource limit, instead of enforcing a minimum of 1. Existing maximum limits, hints and validations remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->