### PR TITLE
fix subdomain edit and improved error handling

### DIFF
--- a/subdomains/src/Models/Subdomain.php
+++ b/subdomains/src/Models/Subdomain.php
@@ -75,7 +75,7 @@ class Subdomain extends Model implements HasLabel
                 throw new Exception('Server has no SRV type');
             }
 
-            $searchName = "{$srvServiceType->value}.{$this->name}";
+            $searchName = "$srvServiceType->value.$this->name";
 
             $payload = [
                 'name' => $searchName,
@@ -111,26 +111,23 @@ class Subdomain extends Model implements HasLabel
             'type' => $this->record_type,
         ])->json();
 
-        if (!$searchResponse['success']) {
-            if (!empty($searchResponse['errors'])) {
-                throw new Exception($searchResponse['errors'][0]['message']);
-            }
-            throw new Exception('Failed to search for existing DNS records');
-        } else {
+        if ($searchResponse['success']) {
             $results = $searchResponse['result'] ?? [];
 
-            if (!empty($results)) {
-                foreach ($results as $record) {
-                    if ($record['id'] !== $this->cloudflare_id) {
-                        throw new Exception('A subdomain with that name already exists');
-                    }
+            foreach ($results as $record) {
+                if ($record['id'] !== $this->cloudflare_id) {
+                    throw new Exception('A subdomain with that name already exists');
                 }
+            }
+        } else {
+            if ($searchResponse['errors'] && count($searchResponse['errors']) > 0) {
+                throw new Exception($searchResponse['errors'][0]['message']);
             }
         }
 
         if ($this->cloudflare_id) {
             // @phpstan-ignore staticMethod.notFound
-            $response = Http::cloudflare()->patch("zones/{$this->domain->cloudflare_id}/dns_records/{$this->cloudflare_id}", $payload)->json();
+            $response = Http::cloudflare()->patch("zones/{$this->domain->cloudflare_id}/dns_records/$this->cloudflare_id", $payload)->json();
         } else {
             // @phpstan-ignore staticMethod.notFound
             $response = Http::cloudflare()->post("zones/{$this->domain->cloudflare_id}/dns_records", $payload)->json();

--- a/subdomains/src/Services/SubdomainService.php
+++ b/subdomains/src/Services/SubdomainService.php
@@ -14,13 +14,13 @@ class SubdomainService
      */
     public function handle(array $data, ?Subdomain $subdomain = null): Subdomain
     {
-        $newSubdomain = false;
+        $newSubdomain = true;
 
         if (is_null($subdomain)) {
             $subdomain = Subdomain::create($data);
-            $newSubdomain = true;
         } else {
             $subdomain->update($data);
+            $newSubdomain = false;
         }
 
         $subdomain->refresh();
@@ -31,6 +31,7 @@ class SubdomainService
             if ($newSubdomain) {
                 $subdomain->delete();
             }
+
             throw $exception;
         }
 


### PR DESCRIPTION
Fixes: #87 

Fixed the Edit workflow so that editing a subdomain updates Cloudflare correctly and does not delete the record on failure (some improved error handling).

**Previous:**
When you edit a subdomain name, the plugin calls Cloudflare in a way that incorrectly treats the existing record as a conflict. Throws exception, and deletes record.

**Now:**
When you edit a subdomain name, the plugin queries Cloudflare records by name and type, then checks each record ID, if record has a different ID, an exception is thrown, otherwise update the record.

Additional error handling:
If New Subdomain is created for the first time and there is an error, delete the record (as previous).
If Subdomain is being edited and there is an error, keep the record, as to not remove a current working record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added preflight validation to detect duplicate or conflicting DNS records earlier.
  * Unified record name handling (including SRV records) to ensure consistent creation and updates.
  * Ensured payload is validated against server allocation IPs for non-SRV records.

* **Refactor**
  * Made create/update flow explicit with safer cleanup and state refresh to avoid deleting existing records on errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->