### PR TITLE
delete subdomain on server delete

### DIFF
--- a/subdomains/src/Providers/SubdomainsPluginProvider.php
+++ b/subdomains/src/Providers/SubdomainsPluginProvider.php
@@ -35,8 +35,8 @@ class SubdomainsPluginProvider extends ServiceProvider
         Server::resolveRelationUsing('subdomains', fn (Server $server) => $server->hasMany(Subdomain::class, 'server_id', 'id'));
 
         Server::deleting(function (Server $server) {
-            /** @phpstan-ignore-next-line */
-            foreach ($server->subdomains()->get() as $subdomain) {
+            /** @phpstan-ignore property.notFound */
+            foreach ($server->subdomains as $subdomain) {
                 try {
                     $subdomain->delete();
                 } catch (Exception $exception) {


### PR DESCRIPTION
Fixes #88 

Added event listener for "deleting" event and deletes subdomain.
Not throwing exception to not interfere with server deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic subdomain cleanup on server deletion: when a server is removed, all associated subdomains are now deleted automatically. Individual deletion failures are caught and reported so cleanup continues, preventing orphaned subdomains and improving consistency and error visibility during server removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->