### PR TITLE
feat(loader): add support for Purpur, Folia and more

### DIFF
--- a/minecraft-modrinth/src/Enums/MinecraftLoader.php
+++ b/minecraft-modrinth/src/Enums/MinecraftLoader.php
@@ -42,7 +42,7 @@ enum MinecraftLoader: string implements HasLabel
      */
     public static function fromTags(array $tags): ?self
     {
-        if (! in_array('minecraft', $tags)) {
+        if (!in_array('minecraft', $tags)) {
             return null;
         }
 


### PR DESCRIPTION
This PR expands the MinecraftLoader enum to support additional popular server forks and proxies. This allows the Minecraft Modrinth plugin to correctly identify the server type and filter compatible plugins/mods from Modrinth more accurately.
Changes

    Added new loaders: Purpur, Folia, Pufferfish, Spigot, Bukkit, and Waterfall.

    Refactored fromTags method: Replaced nested if statements with a more efficient match(true) structure (PHP 8.x).

    Improved tag detection: Added support for common tag variations like papermc, spigotmc, and neoforged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded server loader detection to include Purpur, Folia, Pufferfish, Paper (PaperMC), Spigot (SpigotMC), Bukkit, Velocity, Waterfall, and BungeeCord.
  * Improved alias mapping for more accurate identification of a wider range of Minecraft server setups, reducing misclassification and increasing compatibility.

* **Bug Fixes / Improvements**
  * Cleaner handling when no matching loader is found.
  * Improved display labels for detected loaders (consistent title-casing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->