### PR TITLE
fix: Increase display_color column length to 7 in the generic OIDC pr…

### DIFF
--- a/generic-oidc-providers/database/migrations/001_create_generic_oidc_providers_table.php
+++ b/generic-oidc-providers/database/migrations/001_create_generic_oidc_providers_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->boolean('link_missing_users')->default(false);
             $table->string('display_name');
             $table->string('display_icon')->nullable();
-            $table->string('display_color', 6)->nullable();
+            $table->string('display_color', 7)->nullable();
             $table->string('base_url');
             $table->string('client_id');
             $table->text('client_secret');


### PR DESCRIPTION
Minor change: QoL Improvement.
Increased the length of the 'display_color' field from 6 to 7 characters to accommodate additional color formats. Previously it shortened my "#8b5cf6" to "#8b5cf" which is an entirly different color.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system infrastructure to accommodate longer display color value formats in authentication provider settings. This change expands storage capacity for color identifiers, supporting additional naming conventions and preparing the platform for future enhancements. The modification is transparent to end users and maintains full backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->