### PR TITLE
feat(player-counter): add TeamSpeak 3 ServerQuery support

### DIFF
--- a/player-counter/src/Extensions/Query/Schemas/TeamSpeakQueryTypeSchema.php
+++ b/player-counter/src/Extensions/Query/Schemas/TeamSpeakQueryTypeSchema.php
@@ -74,12 +74,12 @@ class TeamSpeakQueryTypeSchema implements QueryTypeSchemaInterface
             $clients = $this->parseClientList($clientLine);
 
             return [
-                'hostname'        => $this->unescape($info['virtualserver_name'] ?? 'Unknown'),
-                'map'             => 'TeamSpeak',
+                'hostname' => $this->unescape($info['virtualserver_name'] ?? 'Unknown'),
+                'map' => 'TeamSpeak',
                 'current_players' => count($clients),
-                'max_players'     => (int) ($info['virtualserver_maxclients'] ?? 0),
-                'players'         => array_map(fn ($c) => [
-                    'id'   => $c['clid'] ?? '0',
+                'max_players' => (int) ($info['virtualserver_maxclients'] ?? 0),
+                'players' => array_map(fn ($c) => [
+                    'id' => $c['clid'] ?? '0',
                     'name' => $this->unescape($c['client_nickname'] ?? 'Unknown'),
                 ], $clients),
             ];
@@ -94,6 +94,7 @@ class TeamSpeakQueryTypeSchema implements QueryTypeSchemaInterface
         return null;
     }
 
+    /** @param resource $socket */
     private function readUntilError($socket): string
     {
         $data = '';
@@ -110,6 +111,7 @@ class TeamSpeakQueryTypeSchema implements QueryTypeSchemaInterface
                 $data = $trimmed;
             }
         }
+
         return $data;
     }
 
@@ -123,6 +125,7 @@ class TeamSpeakQueryTypeSchema implements QueryTypeSchemaInterface
                 $result[$key] = $value;
             }
         }
+
         return $result;
     }
 
@@ -138,6 +141,7 @@ class TeamSpeakQueryTypeSchema implements QueryTypeSchemaInterface
             }
             $clients[] = $client;
         }
+
         return $clients;
     }
 

--- a/player-counter/src/Extensions/Query/Schemas/TeamSpeakQueryTypeSchema.php
+++ b/player-counter/src/Extensions/Query/Schemas/TeamSpeakQueryTypeSchema.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Boy132\PlayerCounter\Extensions\Query\Schemas;
+
+use App\Models\Allocation;
+use Boy132\PlayerCounter\Extensions\Query\QueryTypeSchemaInterface;
+use Exception;
+
+class TeamSpeakQueryTypeSchema implements QueryTypeSchemaInterface
+{
+    public function getId(): string
+    {
+        return 'teamspeak';
+    }
+
+    public function getName(): string
+    {
+        return 'TeamSpeak 3 (ServerQuery)';
+    }
+
+    public function resolvePort(Allocation $allocation): ?int
+    {
+        $server = $allocation->server;
+        if (!$server) {
+            return null;
+        }
+
+        $variable = $server->variables()->where('env_variable', 'QUERY_PORT')->first();
+        if (!$variable) {
+            return null;
+        }
+
+        $port = (int) ($variable->server_value ?: $variable->default_value);
+
+        return $port > 0 ? $port : null;
+    }
+
+    /** @return ?array{hostname: string, map: string, current_players: int, max_players: int, players: ?array<array{id: string, name: string}>} */
+    public function process(string $ip, int $port): ?array
+    {
+        $socket = null;
+
+        try {
+            $socket = @fsockopen($ip, $port, $errno, $errstr, 5);
+            if ($socket === false) {
+                throw new Exception("Could not connect to TeamSpeak ServerQuery: $errstr ($errno)");
+            }
+
+            stream_set_timeout($socket, 5);
+
+            // Read greeting: "TS3", welcome text, empty line
+            $greeting = fgets($socket);
+            if (!str_starts_with(trim($greeting), 'TS3')) {
+                throw new Exception('Not a TeamSpeak 3 ServerQuery interface');
+            }
+            fgets($socket); // welcome line
+            fgets($socket); // empty line
+
+            // Select first virtual server
+            fwrite($socket, "use sid=1\n");
+            $this->readUntilError($socket);
+
+            // Get server info
+            fwrite($socket, "serverinfo\n");
+            $infoLine = $this->readUntilError($socket);
+
+            // Get client list
+            fwrite($socket, "clientlist\n");
+            $clientLine = $this->readUntilError($socket);
+
+            fwrite($socket, "quit\n");
+
+            $info = $this->parseLine($infoLine);
+            $clients = $this->parseClientList($clientLine);
+
+            return [
+                'hostname'        => $this->unescape($info['virtualserver_name'] ?? 'Unknown'),
+                'map'             => 'TeamSpeak',
+                'current_players' => count($clients),
+                'max_players'     => (int) ($info['virtualserver_maxclients'] ?? 0),
+                'players'         => array_map(fn ($c) => [
+                    'id'   => $c['clid'] ?? '0',
+                    'name' => $this->unescape($c['client_nickname'] ?? 'Unknown'),
+                ], $clients),
+            ];
+        } catch (Exception $exception) {
+            report($exception);
+        } finally {
+            if (!empty($socket)) {
+                fclose($socket);
+            }
+        }
+
+        return null;
+    }
+
+    private function readUntilError($socket): string
+    {
+        $data = '';
+        while (!feof($socket)) {
+            $line = fgets($socket);
+            if ($line === false) {
+                break;
+            }
+            $trimmed = trim($line);
+            if (str_starts_with($trimmed, 'error ')) {
+                break;
+            }
+            if ($trimmed !== '') {
+                $data = $trimmed;
+            }
+        }
+        return $data;
+    }
+
+    /** @return array<string, string> */
+    private function parseLine(string $line): array
+    {
+        $result = [];
+        foreach (explode(' ', $line) as $token) {
+            if (str_contains($token, '=')) {
+                [$key, $value] = explode('=', $token, 2);
+                $result[$key] = $value;
+            }
+        }
+        return $result;
+    }
+
+    /** @return array<int, array<string, string>> */
+    private function parseClientList(string $line): array
+    {
+        $clients = [];
+        foreach (explode('|', $line) as $entry) {
+            $client = $this->parseLine($entry);
+            // Skip ServerQuery clients (client_type=1)
+            if (($client['client_type'] ?? '0') === '1') {
+                continue;
+            }
+            $clients[] = $client;
+        }
+        return $clients;
+    }
+
+    private function unescape(string $value): string
+    {
+        return str_replace(
+            ['\\s', '\\p', '\\/', '\\\\', '\\n', '\\r', '\\t', '\\a', '\\b', '\\f', '\\v'],
+            [' ',   '|',   '/',   '\\',   "\n",  "\r",  "\t",  "\x07", "\x08", "\x0C", "\x0B"],
+            $value
+        );
+    }
+}

--- a/player-counter/src/Models/GameQuery.php
+++ b/player-counter/src/Models/GameQuery.php
@@ -72,7 +72,7 @@ class GameQuery extends Model
         return !in_array($ip, ['0.0.0.0', '::']);
     }
 
-    private static function resolveIp(Allocation $allocation): string
+    protected static function resolveIp(Allocation $allocation): string
     {
         if (config('player-counter.use_alias') && !empty($allocation->ip_alias)) {
             return $allocation->ip_alias;

--- a/player-counter/src/Models/GameQuery.php
+++ b/player-counter/src/Models/GameQuery.php
@@ -39,13 +39,26 @@ class GameQuery extends Model
             return null;
         }
 
-        $ip = config('player-counter.use_alias') && is_ip($allocation->alias) ? $allocation->alias : $allocation->ip;
+        $ip = static::resolveIp($allocation);
         $ip = is_ipv6($ip) ? '[' . $ip . ']' : $ip;
 
         /** @var QueryTypeService $service */
         $service = app(QueryTypeService::class);
 
-        return $service->get($this->query_type)?->process($ip, $allocation->port + ($this->query_port_offset ?? 0));
+        $schema = $service->get($this->query_type);
+        if (!$schema) {
+            return null;
+        }
+
+        // Allow schema to provide its own port resolution (e.g. from server variables)
+        if (method_exists($schema, 'resolvePort')) {
+            $resolvedPort = $schema->resolvePort($allocation);
+            if ($resolvedPort !== null) {
+                return $schema->process($ip, $resolvedPort);
+            }
+        }
+
+        return $schema->process($ip, $allocation->port + ($this->query_port_offset ?? 0));
     }
 
     public static function canRunQuery(?Allocation $allocation): bool
@@ -54,8 +67,17 @@ class GameQuery extends Model
             return false;
         }
 
-        $ip = config('player-counter.use_alias') && is_ip($allocation->alias) ? $allocation->alias : $allocation->ip;
+        $ip = static::resolveIp($allocation);
 
         return !in_array($ip, ['0.0.0.0', '::']);
+    }
+
+    private static function resolveIp(Allocation $allocation): string
+    {
+        if (config('player-counter.use_alias') && !empty($allocation->ip_alias)) {
+            return $allocation->ip_alias;
+        }
+
+        return $allocation->ip;
     }
 }

--- a/player-counter/src/Providers/PlayerCounterPluginProvider.php
+++ b/player-counter/src/Providers/PlayerCounterPluginProvider.php
@@ -12,6 +12,7 @@ use Boy132\PlayerCounter\Extensions\Query\Schemas\GoldSourceQueryTypeSchema;
 use Boy132\PlayerCounter\Extensions\Query\Schemas\MinecraftBedrockQueryTypeSchema;
 use Boy132\PlayerCounter\Extensions\Query\Schemas\MinecraftJavaQueryTypeSchema;
 use Boy132\PlayerCounter\Extensions\Query\Schemas\SourceQueryTypeSchema;
+use Boy132\PlayerCounter\Extensions\Query\Schemas\TeamSpeakQueryTypeSchema;
 use Boy132\PlayerCounter\Filament\Server\Widgets\ServerPlayerWidget;
 use Boy132\PlayerCounter\Models\EggGameQuery;
 use Boy132\PlayerCounter\Models\GameQuery;
@@ -35,6 +36,7 @@ class PlayerCounterPluginProvider extends ServiceProvider
             $service->register(new MinecraftJavaQueryTypeSchema());
             $service->register(new MinecraftBedrockQueryTypeSchema());
             $service->register(new CitizenFXQueryTypeSchema());
+            $service->register(new TeamSpeakQueryTypeSchema());
 
             return $service;
         });


### PR DESCRIPTION
## Summary

- **New schema:** `TeamSpeakQueryTypeSchema` — connects via raw TCP to the TeamSpeak 3 ServerQuery interface, reads server name, max clients and connected players, filters out ServerQuery clients (`client_type=1`), and unescapes TS3 protocol encoding
- **Port resolution hook:** `GameQuery::runQuery()` now checks for an optional `resolvePort(Allocation $allocation): ?int` method on schemas, allowing them to resolve the query port from server variables instead of relying solely on the `query_port_offset`. Schemas without this method continue to work exactly as before
- **Hostname alias fix:** `GameQuery::canRunQuery()` and `runQuery()` now support hostname-based `ip_alias` values (not just raw IPs), which is required for servers bound to `0.0.0.0` behind a reverse proxy

## Why the resolvePort() hook?

TeamSpeak exposes its ServerQuery port as a configurable server variable (`QUERY_PORT`), independent of the voice port. A static offset would break whenever an admin changes the query port. The hook lets the schema read the actual configured value directly from the server.

The hook is fully backwards-compatible — existing schemas and the `query_port_offset` field are unaffected.

## Test plan

- [ ] TeamSpeak 3 server with default ports (voice: 9987, query: 10011) shows player count widget
- [ ] TeamSpeak 3 server with custom `QUERY_PORT` uses the correct port
- [ ] Existing query types (Source, Minecraft, etc.) still work as before
- [ ] Server bound to `0.0.0.0` with a hostname `ip_alias` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TeamSpeak 3 ServerQuery support for player count queries.
  * Added support for query-type specific port resolution.

* **Bug Fixes / Reliability**
  * Improved IP/alias handling for better network configuration flexibility.
  * More robust query execution with safer failure handling and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->