### PR TITLE
docs: use Corepack instead of `npm i -g yarn` in theme setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ A curated list of plugins for the [Pelican Panel](https://pelican.dev).
 
 ### Additional setup for themes
 
-For themes you have to install Node.js 22+ and Yarn beforehand. Example:
+For themes you have to install Node.js 22+ and enable Corepack (which ships with Node.js and provides Yarn). Example:
 
 ```bash
 curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash - 
 sudo apt install -y nodejs
 
-npm i -g yarn
+sudo corepack enable
 ```
 
 ## Plugins

--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ A curated list of plugins for the [Pelican Panel](https://pelican.dev).
 
 ### Additional setup for themes
 
-For themes you have to install Node.js 22+ and enable Corepack (which ships with Node.js and provides Yarn). Example:
+For themes you have to install Node.js 22+. You also need Yarn, either installed directly or provided via Corepack. Example:
 
 ```bash
 curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash - 
 sudo apt install -y nodejs
 
+// Yarn via corepack (recommended)
 sudo corepack enable
+
+// Install yarn globally
+npm i -g yarn
 ```
 
 ## Plugins


### PR DESCRIPTION
The theme setup snippet in `README.md` currently installs Yarn via `npm i -g yarn`, which requires a global npm write and is the legacy way to get Yarn on Node.

Node.js 22 ships with [Corepack](https://nodejs.org/api/corepack.html), the officially supported mechanism for managing package managers (Yarn, pnpm, ...). Enabling Corepack is a single command, avoids the global npm install, and makes the Yarn version pinned per-project (via the `packageManager` field in a theme's `package.json`) rather than whatever happens to be globally installed on the host.

## Changes

- `## Additional setup for themes` paragraph mentions Corepack instead of a global Yarn install.
- Replaces `npm i -g yarn` with `sudo corepack enable`.

No other changes; the NodeSource install step is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated theme setup to reflect that Yarn can be provided either via direct install or via Node.js Corepack; example commands updated to include enabling Corepack before installing Yarn globally and removed prior requirement to have Yarn preinstalled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->