### PR TITLE
Add Chatwoot plugin and provider

### DIFF
--- a/chatwoot/README.md
+++ b/chatwoot/README.md
@@ -1,0 +1,12 @@
+# Chatwoot Widget (by Boy132)
+
+Adds a Chatwoot live chat widget to all panels for real-time customer support.
+
+## Features
+
+- Chatwoot live chat integration
+- Configurable through plugin settings
+
+## Credits
+
+Original Tawk.to widget by Boy132. Edited by Philip E to work with Chatwoot.

--- a/chatwoot/config/chatwoot.php
+++ b/chatwoot/config/chatwoot.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'base_url' => env('CHATWOOT_BASE_URL'),
+    'website_token' => env('CHATWOOT_WEBSITE_TOKEN'),
+];

--- a/chatwoot/plugin.json
+++ b/chatwoot/plugin.json
@@ -1,0 +1,15 @@
+{
+    "id": "chatwoot",
+    "name": "Chatwoot",
+    "author": "Boy132 (edited by Philip E)",
+    "version": "1.0.0",
+    "description": "Adds a Chatwoot widget to all panels",
+    "category": "plugin",
+    "url": "https://github.com/pelican-dev/plugins/tree/main/chatwoot",
+    "update_url": null,
+    "namespace": "Boy132\\Chatwoot",
+    "class": "ChatwootPlugin",
+    "panels": null,
+    "panel_version": null,
+    "composer_packages": null
+}

--- a/chatwoot/src/ChatwootPlugin.php
+++ b/chatwoot/src/ChatwootPlugin.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Boy132\Chatwoot;
+
+use App\Contracts\Plugins\HasPluginSettings;
+use App\Traits\EnvironmentWriterTrait;
+use Filament\Contracts\Plugin;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Filament\Panel;
+
+class ChatwootPlugin implements HasPluginSettings, Plugin {
+    use EnvironmentWriterTrait;
+
+    public function getId(): string {
+        return 'chatwoot';
+    }
+
+    public function register(Panel $panel): void {}
+
+    public function boot(Panel $panel): void {}
+
+    public function getSettingsForm(): array {
+        return [
+            TextInput::make('base_url')
+                ->label('Base URL')
+                ->required()
+                ->default(fn () => config('chatwoot.base_url')),
+            TextInput::make('website_token')
+                ->label('Website Token')
+                ->required()
+                ->default(fn () => config('chatwoot.website_token')),
+        ];
+    }
+
+    public function saveSettings(array $data): void {
+        $this->writeToEnvironment([
+            'CHATWOOT_BASE_URL' => $data['base_url'],
+            'CHATWOOT_WEBSITE_TOKEN' => $data['website_token'],
+        ]);
+
+        Notification::make()
+            ->title('Settings saved')
+            ->success()
+            ->send();
+    }
+}

--- a/chatwoot/src/Providers/ChatwootPluginProvider.php
+++ b/chatwoot/src/Providers/ChatwootPluginProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Boy132\Chatwoot\Providers;
+
+use Filament\Support\Facades\FilamentView;
+use Filament\View\PanelsRenderHook;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+
+class ChatwootPluginProvider extends ServiceProvider {
+    public function boot(): void {
+        $baseUrl = config('chatwoot.base_url');
+        $websiteToken = config('chatwoot.website_token');
+
+        if ($baseUrl && $websiteToken) {
+            FilamentView::registerRenderHook(
+                PanelsRenderHook::STYLES_BEFORE,
+                fn () => Blade::render(<<<'HTML'
+                <!--Start of Chatwoot Script-->
+                <script type="text/javascript">
+                    (function(d,t) {
+                        var BASE_URL="{{ $baseUrl }}";
+                        var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+                        g.src=BASE_URL+"/packs/js/sdk.js";
+                        g.defer = true;
+                        g.async = true;
+                        s.parentNode.insertBefore(g,s);
+                        g.onload=function(){
+                            window.chatwootSDK.run({
+                                websiteToken: '{{ $websiteToken }}',
+                                baseUrl: BASE_URL
+                            })
+                        }
+                    })(document,"script");
+                </script>
+                <!--End of Chatwoot Script-->
+            HTML, [
+                    'baseUrl' => $baseUrl,
+                    'websiteToken' => $websiteToken,
+                ])
+            );
+        }
+    }
+}


### PR DESCRIPTION
Add Chatwoot plugin and provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Chatwoot live chat widget plugin for real-time customer support integration
  * Added settings form to configure Chatwoot base URL and website token
  * Automatically injects Chatwoot SDK into all panels upon configuration
  * Settings persist securely to environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->