### PR TITLE
register: fix username label and add uniqueness check

### DIFF
--- a/register/src/Filament/Pages/Auth/Register.php
+++ b/register/src/Filament/Pages/Auth/Register.php
@@ -46,6 +46,8 @@ class Register extends BaseRegister
 
         return $parent
             ->name('username')
-            ->statePath('username');
+            ->statePath('username')
+            ->label(__('profile.username'))
+            ->unique($this->getUserModel(), 'username');
     }
 }

--- a/register/src/Filament/Pages/Auth/Register.php
+++ b/register/src/Filament/Pages/Auth/Register.php
@@ -47,7 +47,7 @@ class Register extends BaseRegister
         return $parent
             ->name('username')
             ->statePath('username')
-            ->label(__('profile.username'))
+            ->label(trans('profile.username'))
             ->unique($this->getUserModel(), 'username');
     }
 }


### PR DESCRIPTION
before:                                                                                                
                                                                                                         
the username override renames the parent's name input but keeps the parent's label, which resolves to  
"name". the form rendered a field labeled "name" while binding to the username column users sign in with.

the override also dropped the parent's unique check, so duplicate-username submissions fell through to user creation and surfaced the database unique index violation as an unhandled error. 

change:

added an explicit username label using the panel's existing translation key, and a unique validation rule scoped to the username column. mirrors how the parent handles the email field.                                                                                
                                                            
after:

the field renders with the label "Username". duplicate submissions show "The username has already been taken."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registration username now enforces uniqueness to prevent duplicate accounts.
  * Username label is localized, showing the correct text for the user's language.
  * Validation and labeling improvements ensure clearer feedback on the registration form and reduce sign-up errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->