### PR TITLE
[Player Counter] Allow use of hostnames as aliases when resolving query address

### DIFF
--- a/player-counter/src/Models/GameQuery.php
+++ b/player-counter/src/Models/GameQuery.php
@@ -43,8 +43,8 @@ class GameQuery extends Model
             return null;
         }
 
-        $ip = config('player-counter.use_alias') && is_ip($server->allocation->alias) ? $server->allocation->alias : $server->allocation->ip;
-        $ip = is_ipv6($ip) ? '[' . $ip . ']' : $ip;
+        $host = static::getQueryHost($server->allocation);
+        $host = is_ipv6($host) ? '[' . $host . ']' : $host;
 
         $port = $server->allocation->port + ($this->query_port_offset ?? 0);
 
@@ -59,7 +59,7 @@ class GameQuery extends Model
         /** @var QueryTypeService $service */
         $service = app(QueryTypeService::class);
 
-        return $service->get($this->query_type)?->process($server, $ip, $port);
+        return $service->get($this->query_type)?->process($server, $host, $port);
     }
 
     public static function canRunQuery(?Allocation $allocation): bool
@@ -68,8 +68,19 @@ class GameQuery extends Model
             return false;
         }
 
-        $ip = config('player-counter.use_alias') && is_ip($allocation->alias) ? $allocation->alias : $allocation->ip;
+        $host = static::getQueryHost($allocation);
 
-        return !in_array($ip, ['0.0.0.0', '::']);
+        return !blank($host) && !in_array($host, ['0.0.0.0', '::'], true);
+    }
+
+    protected static function getQueryHost(Allocation $allocation): string
+    {
+        $alias = trim((string) $allocation->alias);
+
+        if (config('player-counter.use_alias') && $alias !== '') {
+            return $alias;
+        }
+
+        return $allocation->ip;
     }
 }


### PR DESCRIPTION
I'd found that when trying to use this plugin, that the player counts weren't showing up on any of the servers I was hosting.

My allocation was on 0.0.0.0, and alias set as the hostname so the plugin wasn't activating for them. 

If there's a reason for that, happy to close this, but this is what I've been using locally to get this working and figured its worth adding upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 address handling in game server queries to ensure proper formatting.
  * Enhanced host validation to prevent invalid query attempts against reserved addresses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pelican-dev/plugins/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->